### PR TITLE
feat: terraform provider has been published

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo will introduce you to the basic concepts and tools you'll need to depl
 - [./nuon](./nuon): Terraform for deploying an example app using the Nuon platform.
 - [./example](./example): Source code for the components of the example app.
 - [./install-roles](./install-roles): The IAM roles you need to provision new installs.
-- [./scripts](./scripts): Scripts for installing our CLI and Terraform provider.
+- [./scripts](./scripts): Utility scripts.
 
 ## Getting Started
 
@@ -17,7 +17,7 @@ To get started using Nuon, you'll need to sign up for an account, and install ou
 1. A build server and runner will be provisioned for you automatically.
 1. Connect your Github account.
 1. Fork and clone this repo.
-1. Run the install scripts in [./scripts](./scripts).
+1. Run `./scripts/install-cli.sh` to install our CLI.
 1. Open a terminal, and copy your auth token and org ID from the Dashboard:
     1. `export NUON_API_TOKEN={{ your_auth_token }}`
     1. `export NUON_ORG_ID={{ your_org_id }}`

--- a/nuon/versions.tf
+++ b/nuon/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     nuon = {
-      source  = "terraform.local/local/nuon"
-      version = "0.0.1"
+      source  = "nuonco/nuon"
+      version = "~> 0.1"
     }
   }
 }

--- a/scripts/install-terraform-provider.sh
+++ b/scripts/install-terraform-provider.sh
@@ -1,1 +1,0 @@
-/bin/bash -c "$(curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/terraform-provider-nuon/install.sh)"


### PR DESCRIPTION
We no longer need the local install scripts, now that provider has been published to the Terraform registry.